### PR TITLE
Parse "mon"/"mons" token as "month"/"months" in interval parsing beca…

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -810,7 +810,7 @@ impl FromStr for IntervalUnit {
             "century" | "centuries" => Ok(Self::Century),
             "decade" | "decades" => Ok(Self::Decade),
             "year" | "years" => Ok(Self::Year),
-            "month" | "months" => Ok(Self::Month),
+            "month" | "months" | "mon" | "mons" => Ok(Self::Month),
             "week" | "weeks" => Ok(Self::Week),
             "day" | "days" => Ok(Self::Day),
             "hour" | "hours" => Ok(Self::Hour),


### PR DESCRIPTION
…use postgres uses the "mon" format

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
